### PR TITLE
Provide files for a secure system installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ These files enable greater convenience for MoltenGamepad
 
 `gendevices` has files describing controllers that create generic drivers for them.
 
-`profiles` has files describing control profiles
+`profiles` has files describing control profiles.
+
+`etc` has useful system config files for a secure MoltenGamepad system setup.
 
 This repo should keep files up-to-date with MoltenGamepad's master branch.

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,3 +1,3 @@
 # System Files
 
-A system-wide installation of MoltenGamepad can offer several benefits. Base devices will *always* be invisible to regular users without having to change permissions, and virtual devices will always be visible. Systemd can make sure a directory is available for MG's fifo, and start it automatically. Run install.sh to deploy this setup.
+A system-wide installation of MoltenGamepad can offer several benefits. Base devices will *always* be invisible to regular users without having to change permissions, and virtual devices will always be visible. Systemd can make sure a directory is available for MG's fifo, and start it automatically. Run `./install.sh` from this directory to deploy this setup.

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,3 @@
+# System Files
+
+A system-wide installation of MoltenGamepad can offer several benefits. Base devices will *always* be invisible to regular users without having to change permissions, and virtual devices will always be visible. Systemd can make sure a directory is available for MG's fifo, and start it automatically. Run install.sh to deploy this setup.

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+# Only root can do anything useful here, so might as well...
+[[ $EUID -ne 0 ]] && exec sudo "$0"
+
+# Create system user and group for MG.
+useradd -r -U gamepad
+
+# Install the files contained in the repo.
+cd "$(dirname "$0")"
+install -Dm0644 profile-sdl2.sh /etc/profile.d/sdl2-gamecontroller.sh
+install -Dm0644 systemd.service /etc/systemd/system/moltengamepad.service 
+install -Dm0644 tmpfiles.conf /etc/tmpfiles.d/moltengamepad.conf
+install -Dm0644 udev.rules /etc/udev/rules.d/90-gamepad.rules
+
+# Reload the various services we have affected.
+udevadm control --reload
+sytemd-tmpfiles --create
+systemctl daemon-reload
+systemctl enable moltengamepad.service
+
+# Tell the user we're done and what to do next.
+echo "Installation of system files complete. Install the MoltenGamepad binary"
+echo "as /usr/local/bin/moltengamepad and run systemctl start moltengamepad"
+echo "to start system-mode MoltenGamepad."

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -16,7 +16,7 @@ install -Dm0644 udev.rules /etc/udev/rules.d/90-gamepad.rules
 
 # Reload the various services we have affected.
 udevadm control --reload
-sytemd-tmpfiles --create
+systemd-tmpfiles --create
 systemctl daemon-reload
 systemctl enable moltengamepad.service
 

--- a/etc/profile-sdl2.sh
+++ b/etc/profile-sdl2.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Installs as /etc/profile.d/sdl2-gamecontroller.sh
-# Creates a system-wide SDL2 mapping for any device that mimics xpad.
+# Creates a system-wide SDL2 mapping for MG's default configuration as well as
+# any device that mimics xpad.
 export SDL_GAMECONTROLLERCONFIG="$SDL_GAMECONTROLLERCONFIG
+03000000010000000100000001000000,MoltenGamepad,platform:Linux,a:b0,b:b1,x:b2,y:b3,back:b6,start:b7,guide:b8,leftshoulder:b4,rightshoulder:b5,leftstick:b9,rightstick:b10,leftx:a0,lefty:a1,rightx:a3,righty:a4,lefttrigger:a2,righttrigger:a5,dpup:b11,dpleft:b13,dpdown:b12,dpright:b14,
 030000005e0400008e02000010010000,XPad,platform:Linux,a:b0,b:b1,x:b2,y:b3,back:b6,start:b7,leftshoulder:b4,rightshoulder:b5,leftstick:b9,guide:b8,rightstick:b10,lefttrigger:a2,righttrigger:a5,leftx:a0,lefty:a1,rightx:a3,righty:a4,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,"

--- a/etc/profile-sdl2.sh
+++ b/etc/profile-sdl2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Installs as /etc/profile.d/sdl2-gamecontroller.sh
+# Creates a system-wide SDL2 mapping for any device that mimics xpad.
+export SDL_GAMECONTROLLERCONFIG="$SDL_GAMECONTROLLERCONFIG
+030000005e0400008e02000010010000,XPad,platform:Linux,a:b0,b:b1,x:b2,y:b3,back:b6,start:b7,leftshoulder:b4,rightshoulder:b5,leftstick:b9,guide:b8,rightstick:b10,lefttrigger:a2,righttrigger:a5,leftx:a0,lefty:a1,rightx:a3,righty:a4,dpup:h0.1,dpleft:h0.8,dpdown:h0.4,dpright:h0.2,"

--- a/etc/systemd.service
+++ b/etc/systemd.service
@@ -2,8 +2,6 @@
 
 [Unit]
 Description=MoltenGamepad Event Translator
-After=network.target
-After=bluetooth.target
 
 [Service]
 Type=forking

--- a/etc/systemd.service
+++ b/etc/systemd.service
@@ -1,0 +1,21 @@
+# Installs as /etc/systemd/system/moltengamepad.service.
+
+[Unit]
+Description=MoltenGamepad Event Translator
+After=network.target
+After=bluetooth.target
+
+[Service]
+Type=forking
+User=gamepad
+Group=gamepad
+PIDFile=/var/run/moltengamepad/pid
+ExecStart=/usr/local/bin/moltengamepad \
+ --daemon --pidfile /var/run/moltengamepad/pid \
+ --make-fifo --fifo-path /var/run/moltengamepad/fifo
+ExecStop=/usr/bin/kill $MAINPID
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=default.target

--- a/etc/tmpfiles.conf
+++ b/etc/tmpfiles.conf
@@ -1,0 +1,2 @@
+# Installs as /etc/tmpfiles.d/moltengamepad.conf
+D /var/run/moltengamepad 0755 gamepad gamepad

--- a/etc/udev.rules
+++ b/etc/udev.rules
@@ -1,0 +1,15 @@
+# udev rules for system-wide MoltenGamepad.
+# Installs as 90-gamepad.rules.
+
+# Allow gamepad user access to uinput.
+KERNEL=="uinput" RUN+="/usr/bin/setfacl -m gamepad:rw- %E{DEVNAME}"
+
+# Virtual event devices should be world-usable.
+SUBSYSTEM=="input", ACTION=="add", DEVPATH=="*virtual*", \
+ OWNER:="gamepad", GROUP:="input", MODE:="0666"
+
+# When a non-virtual gamepad device appears, hide it.
+SUBSYSTEM=="input", ACTION=="add", \
+ ENV{ID_INPUT_JOYSTICK}=="?*", DEVPATH!="*virtual*", \
+ OWNER:="gamepad", GROUP:="gamepad", MODE:="0600", \
+ RUN+="/usr/bin/setfacl -m mask:--- %E{DEVNAME}"


### PR DESCRIPTION
I use a system-wide MG installation for my gamepads. MG runs as the user and group `gamepad`. Udev sets all non-virtual joysticks to be readable only to `gamepad`, but virtual devices are world-usable. Thus the permissions hack doesn't need to be used. systemd-tmpfiles makes sure a place exists for MG to store its runtime files. The systemd service starts it all up, and the profile.d script makes sure SDL2 apps understand what they are seeing.

I think this setup has convenience and security benefits, so I'd like to share my config files along with a script to deploy them automatically. I've removed the bits that are specific to my personal setup, and changed them to be more generic.
