### PR TITLE
Create a pair of profiles for mapping the dpad to the left stick.

### DIFF
--- a/profiles/dpad_to_ls_off
+++ b/profiles/dpad_to_ls_off
@@ -1,0 +1,7 @@
+# Returns the profile to normal after applying dpad-to-ls.
+gamepad.left = left
+gamepad.right = right
+gamepad.up = up
+gamepad.down = down
+gamepad.leftright = (left, right)
+gamepad.updown = (up, down)

--- a/profiles/dpad_to_ls_on
+++ b/profiles/dpad_to_ls_on
@@ -1,0 +1,10 @@
+# Some older games ignore the d-pad. Explicitly mapping the dpad to the left
+# stick is also good for games that should let the user use either the dpad
+# or left stick, but don't support it for one reason or another.
+# Examples include Atomic Bomberman, Megabyte Punch, and Lethal League.
+#gamepad.left = -left_x
+#gamepad.right = +left_x
+#gamepad.up = -left_y
+#gamepad.down = +left_y
+gamepad.leftright = left_x
+gamepad.updown = left_y


### PR DESCRIPTION
This is good for old games that ignore the dpad or games that should let you use either method but for some reason or another don't.

Switching it on and off while MG is running is a matter of...

```
echo "load profiles from dpad_to_ls_on" > $mgfifo
echo "load profiles from dpad_to_ls_off" > $mgfifo
```