### PR TITLE
Mappings for the DualShock3 Controller

### DIFF
--- a/gendevices/11-ds3-standard.cfg
+++ b/gendevices/11-ds3-standard.cfg
@@ -1,0 +1,61 @@
+# This profile matches DualShock3 controllers from Linux kernel 4.12 and onwards.
+# In kernel 4.12, DualShock3 controllers were made compliant with the Linux
+# gamepad spec. The major differences from earlier kernels is that the accelerometer
+# data is now placed in its own input seperate from the gamepad. Also, the DualShock3's
+# button keys were updated to match xpad layouts.
+[driver="sony" events="subset" order="11"]
+
+# Options
+
+name = "dualshock3"
+devname = "ds3_"
+exclusive = "true"
+change_permissions = "true"
+flatten = "false"
+rumble = "true"
+
+# Event mappings
+
+abs(000) = "left_x", "Left stick X axis"
+abs(001) = "left_y", "Left stick Y axis"
+abs(003) = "right_x", "Right stick X axis"
+abs(004) = "right_y", "Right stick Y axis"
+abs(002) = "l2_axis", "L2 analog values"
+abs(005) = "r2_axis", "R2 analog values"
+
+key(304) = "cross", "Cross (X) face button"
+key(305) = "circle", "Circle face button"
+key(307) = "triangle", "Triangle face button"
+key(308) = "square", "Square face button"
+key(310) = "l1", "L1 shoulder button"
+key(311) = "r1", "R1 shoulder button"
+key(312) = "l2", "L2 shoulder button"
+key(313) = "r2", "R2 shoulder button"
+key(317) = "l3", "Left stick click"
+key(318) = "r3", "Right stick click"
+key(315) = "start", "Start button"
+key(314) = "select", "Select button"
+key(316) = "home", "Home button"
+key(544) = "up", "D-pad up"
+key(545) = "down", "D-pad down"
+key(546) = "left", "D-pad left"
+key(547) = "right", "D-pad right"
+
+# Aliases
+
+alias primary cross
+alias secondary circle
+alias third square
+alias fourth triangle
+
+alias mode home
+
+alias tr r1
+alias tr2_axis_btn r2
+alias tr2_axis r2_axis
+alias tl l1
+alias tl2_axis_btn l2
+alias tl2_axis l2_axis
+
+alias thumbl l3
+alias thumbr r3


### PR DESCRIPTION
This profile matches DualShock3 controllers from Linux kernel 4.12 and onward. In kernel 4.12, DualShock3 controllers were made compliant with the Linux gamepad spec. The major differences from earlier kernels is that the accelerometer data is now placed in its own input separate from the gamepad. Also, the DualShock3's button keys were updated to match xpad layouts.

The existing profile sony-standard.cfg does not match the DualShock3 since there are some small differences with regards to how the D-Pad is mapped.